### PR TITLE
Improve CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 8.0snapshot
+  - 8.0
+  - nightly
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: nightly
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/


### PR DESCRIPTION
removed 'snapshot' prefix from php 8.0
added nighlty php version testing with allowing to fail